### PR TITLE
Sort list by purchase urgency and alphabetical order

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -9,6 +9,7 @@ import {
 import { db } from './config';
 import {
 	getFutureDate,
+	transformToJSDate,
 	getDaysBetweenDates,
 	getNextPurchaseDate,
 } from '../utils';
@@ -90,9 +91,6 @@ export async function updateItem(listId, item) {
 		totalPurchases,
 	} = item;
 
-	const transformToJSDate = (date) => {
-		return date.toDate();
-	};
 	const prevEstimate = getDaysBetweenDates(
 		transformToJSDate(dateCreated),
 		transformToJSDate(dateNextPurchased),
@@ -125,7 +123,7 @@ export async function deleteItem() {
 
 export function comparePurchaseUrgency(data) {
 	console.log(data);
-	const sortedData = data.sort((a, b) => {
+	const alphabeticalData = data.sort((a, b) => {
 		const nameA = a.name.toLowerCase();
 		const nameB = b.name.toLowerCase();
 
@@ -139,12 +137,21 @@ export function comparePurchaseUrgency(data) {
 
 		return 0;
 	});
-	return sortedData;
-	//walk the array, checking each item
-	//use getDaysBetweenDates function to compare current date to nextPurchaseDate of item
-	//if 7 days or fewer push to top (soon)
-	//if between 7 & 30 days push next (kind of soon)
-	//if 30+ days push next (not very soon)
-	//if 60+ since last purchase date push last (inactive)
-	//then sort alphabetically within purchase categories
+	const sortByPurchaseData = alphabeticalData.sort((a, b) => {
+		const nextPurchaseA = transformToJSDate(a.dateNextPurchased);
+		const nextPurchaseB = transformToJSDate(b.dateNextPurchased);
+		const today = new Date();
+		const daysUntilNextPurchaseA = getDaysBetweenDates(nextPurchaseA, today);
+		const daysUntilNextPurchaseB = getDaysBetweenDates(nextPurchaseB, today);
+		if (daysUntilNextPurchaseA < daysUntilNextPurchaseB) {
+			return -1;
+		}
+
+		if (daysUntilNextPurchaseA > daysUntilNextPurchaseB) {
+			return 1;
+		}
+
+		return 0;
+	});
+	return sortByPurchaseData;
 }

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -13,6 +13,7 @@ import {
 	getDaysBetweenDates,
 	getNextPurchaseDate,
 	getItemDaysUntilNextPurchase,
+	getItemDaysSinceLastPurchase,
 	sortItems,
 } from '../utils';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
@@ -126,7 +127,7 @@ export async function deleteItem() {
 export function comparePurchaseUrgency(data) {
 	const inActiveItems = sortItems(
 		data.filter((item) => {
-			return getItemDaysUntilNextPurchase(item) > 60;
+			return getItemDaysSinceLastPurchase(item) > 60;
 		}),
 	);
 

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -123,7 +123,23 @@ export async function deleteItem() {
 
 export function comparePurchaseUrgency(data) {
 	console.log(data);
-	const alphabeticalData = data.sort((a, b) => {
+	const today = new Date();
+	// splitting data into inactive and active
+	const inActiveItems = data.filter((item) => {
+		return (
+			getDaysBetweenDates(transformToJSDate(item.dateLastPurchased), today) > 60
+		);
+	});
+	const activeItems = data.filter((item) => {
+		return (
+			item.dateLastPurchased === null ||
+			getDaysBetweenDates(transformToJSDate(item.dateLastPurchased), today) < 60
+		);
+	});
+	console.log('inactive items', inActiveItems);
+	console.log('active items', activeItems);
+	// sorting active items
+	const alphabeticalActiveData = activeItems.sort((a, b) => {
 		const nameA = a.name.toLowerCase();
 		const nameB = b.name.toLowerCase();
 
@@ -137,10 +153,9 @@ export function comparePurchaseUrgency(data) {
 
 		return 0;
 	});
-	const sortByPurchaseData = alphabeticalData.sort((a, b) => {
+	const sortByPurchaseActiveData = alphabeticalActiveData.sort((a, b) => {
 		const nextPurchaseA = transformToJSDate(a.dateNextPurchased);
 		const nextPurchaseB = transformToJSDate(b.dateNextPurchased);
-		const today = new Date();
 		const daysUntilNextPurchaseA = getDaysBetweenDates(nextPurchaseA, today);
 		const daysUntilNextPurchaseB = getDaysBetweenDates(nextPurchaseB, today);
 		if (daysUntilNextPurchaseA < daysUntilNextPurchaseB) {
@@ -153,5 +168,43 @@ export function comparePurchaseUrgency(data) {
 
 		return 0;
 	});
-	return sortByPurchaseData;
+
+	// inactive sorting
+	const alphabeticalInactiveData = inActiveItems.sort((a, b) => {
+		const nameA = a.name.toLowerCase();
+		const nameB = b.name.toLowerCase();
+
+		if (nameA < nameB) {
+			return -1;
+		}
+
+		if (nameA > nameB) {
+			return 1;
+		}
+
+		return 0;
+	});
+	const sortByPurchaseInactiveData = alphabeticalInactiveData.sort((a, b) => {
+		const nextPurchaseA = transformToJSDate(a.dateNextPurchased);
+		const nextPurchaseB = transformToJSDate(b.dateNextPurchased);
+		const daysUntilNextPurchaseA = getDaysBetweenDates(nextPurchaseA, today);
+		const daysUntilNextPurchaseB = getDaysBetweenDates(nextPurchaseB, today);
+		if (daysUntilNextPurchaseA < daysUntilNextPurchaseB) {
+			return -1;
+		}
+
+		if (daysUntilNextPurchaseA > daysUntilNextPurchaseB) {
+			return 1;
+		}
+
+		return 0;
+	});
+	const sortedData = [
+		...sortByPurchaseActiveData,
+		...sortByPurchaseInactiveData,
+	];
+	return sortedData;
 }
+
+// working but a little buggy. works fine while our "bread" item is inactive (set date in database)
+// but if you then click the check on the bread item and it's added back into the active list, it doesn't get re-sorted with activeData and remains at end of list

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -135,7 +135,7 @@ export function comparePurchaseUrgency(data) {
 		data.filter((item) => {
 			return (
 				item.dateLastPurchased === null ||
-				getItemDaysUntilNextPurchase(item) < 60
+				getItemDaysSinceLastPurchase(item) < 60
 			);
 		}),
 	);

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -122,3 +122,29 @@ export async function deleteItem() {
 	 * this function must accept!
 	 */
 }
+
+export function comparePurchaseUrgency(data) {
+	console.log(data);
+	const sortedData = data.sort((a, b) => {
+		const nameA = a.name.toLowerCase();
+		const nameB = b.name.toLowerCase();
+
+		if (nameA < nameB) {
+			return -1;
+		}
+
+		if (nameA > nameB) {
+			return 1;
+		}
+
+		return 0;
+	});
+	return sortedData;
+	//walk the array, checking each item
+	//use getDaysBetweenDates function to compare current date to nextPurchaseDate of item
+	//if 7 days or fewer push to top (soon)
+	//if between 7 & 30 days push next (kind of soon)
+	//if 30+ days push next (not very soon)
+	//if 60+ since last purchase date push last (inactive)
+	//then sort alphabetically within purchase categories
+}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import './ListItem.css';
 import { updateItem } from '../api/firebase';
+import { getItemDaysUntilNextPurchase } from '../utils';
 
 export function ListItem({ item, listId }) {
 	const [checked, setChecked] = useState(false);
@@ -22,6 +23,24 @@ export function ListItem({ item, listId }) {
 		}
 	}, [checked, item.dateLastPurchased]);
 
+	const purchaseUrgencyMessage = (item) => {
+		if (getItemDaysUntilNextPurchase(item) <= 7) {
+			return 'Soon!';
+		} else if (
+			getItemDaysUntilNextPurchase(item) > 7 &&
+			getItemDaysUntilNextPurchase(item) < 30
+		) {
+			return "You've got some time";
+		} else if (
+			getItemDaysUntilNextPurchase(item) >= 30 &&
+			getItemDaysUntilNextPurchase(item) < 60
+		) {
+			return 'Not for a while';
+		} else {
+			return "You don't seem to be buying this anymore";
+		}
+	};
+
 	return (
 		<li className="ListItem">
 			<label htmlFor={item.id}>
@@ -33,6 +52,8 @@ export function ListItem({ item, listId }) {
 
 				{item.name}
 			</label>
+			<li>Purchase again: {purchaseUrgencyMessage(item)}</li>
+			<br></br>
 		</li>
 	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -36,7 +36,7 @@ export function ListItem({ item, listId }) {
 			return "You've got a bit of time";
 		} else if (
 			getItemDaysUntilNextPurchase(item) >= 30 &&
-			getItemDaysUntilNextPurchase(item) < 60
+			getItemDaysSinceLastPurchase(item) < 60
 		) {
 			return 'Not for a while';
 		} else if (getItemDaysSinceLastPurchase(item) > 60) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 import './ListItem.css';
 import { updateItem } from '../api/firebase';
-import { getItemDaysUntilNextPurchase } from '../utils';
+import {
+	getItemDaysUntilNextPurchase,
+	getItemDaysSinceLastPurchase,
+} from '../utils';
 
 export function ListItem({ item, listId }) {
 	const [checked, setChecked] = useState(false);
@@ -30,14 +33,16 @@ export function ListItem({ item, listId }) {
 			getItemDaysUntilNextPurchase(item) > 7 &&
 			getItemDaysUntilNextPurchase(item) < 30
 		) {
-			return "You've got some time";
+			return "You've got a bit of time";
 		} else if (
 			getItemDaysUntilNextPurchase(item) >= 30 &&
 			getItemDaysUntilNextPurchase(item) < 60
 		) {
 			return 'Not for a while';
-		} else {
+		} else if (getItemDaysSinceLastPurchase(item) > 60) {
 			return "You don't seem to be buying this anymore";
+		} else {
+			return "You haven't purchased this item yet!";
 		}
 	};
 

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -11,6 +11,11 @@ export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
 
+// transforms Firebase date object to JS date object
+export function transformToJSDate(date) {
+	return date.toDate();
+}
+
 /**
  * startDate and endDate are required to be two JavaScript Date objects in order for the compare function to work
  * @param {Date} startDate

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -13,7 +13,7 @@ export function getFutureDate(offset) {
 
 // transforms Firebase date object to JS date object
 export function transformToJSDate(date) {
-	return date.toDate();
+	return date?.toDate();
 }
 
 /**
@@ -22,7 +22,7 @@ export function transformToJSDate(date) {
  * @param {Date} endDate
  */
 export function getDaysBetweenDates(startDate, endDate) {
-	let timeDifference = endDate.getTime() - startDate.getTime();
+	let timeDifference = endDate?.getTime() - startDate?.getTime();
 	let totalDays = Math.abs(timeDifference / ONE_DAY_IN_MILLISECONDS);
 	return Math.floor(totalDays);
 }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,2 +1,3 @@
 export * from './dates';
 export * from './hooks';
+export * from './items';

--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -7,6 +7,13 @@ export function getItemDaysUntilNextPurchase(item) {
 	return getDaysBetweenDates(nextPurchase, today);
 }
 
+export function getItemDaysSinceLastPurchase(item) {
+	const today = new Date();
+	const lastPurchase = transformToJSDate(item.dateLastPurchased);
+
+	return getDaysBetweenDates(lastPurchase, today);
+}
+
 export function sortItems(data) {
 	return data.sort((a, b) => {
 		const daysUntilNextPurchaseA = getItemDaysUntilNextPurchase(a);

--- a/src/utils/items.js
+++ b/src/utils/items.js
@@ -1,0 +1,20 @@
+import { transformToJSDate, getDaysBetweenDates } from './dates';
+
+export function getItemDaysUntilNextPurchase(item) {
+	const today = new Date();
+	const nextPurchase = transformToJSDate(item.dateNextPurchased);
+
+	return getDaysBetweenDates(nextPurchase, today);
+}
+
+export function sortItems(data) {
+	return data.sort((a, b) => {
+		const daysUntilNextPurchaseA = getItemDaysUntilNextPurchase(a);
+		const daysUntilNextPurchaseB = getItemDaysUntilNextPurchase(b);
+
+		return (
+			daysUntilNextPurchaseA - daysUntilNextPurchaseB ||
+			a.name.localeCompare(b.name)
+		);
+	});
+}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,6 +1,7 @@
 import { ListItem } from '../components';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { comparePurchaseUrgency } from '../api/firebase';
 import Chippy3 from '/img/Chippy3.gif';
 import './List.css';
 
@@ -51,7 +52,7 @@ export function List({ data, listId }) {
 			</form>
 			<ul>
 				{/* filters the list to match the user's query as user types, then maps over the items that match the filter to display them */}
-				{data
+				{comparePurchaseUrgency(data)
 					.filter((item) =>
 						item.name?.toLowerCase().includes(query.toLowerCase()),
 					)


### PR DESCRIPTION
## Description

- We added a comparePurchaseUrgency function to firebase.js api which filters the data into two arrays for sorting: inactive items and active items. Once the data in each array is sorted, the arrays are concatenated so the full list is displayed in the desired order.
- We also added an items.js util file with 3 helper functions - one to get the days until an item's next purchase date (used for sorting active items), one to get the days since an item's last purchase date (used to identify inactive items), and a sortItems function to be used for sorting items first by days until next purchase, and then alphabetically.
- Currently this function sorts a list first by next purchase date, then alphabetically if the next purchase date is the same.
- We call comparePurchaseUrgency on the data within the JSX of List.jsx, before the data is filtered and mapped into ListItems
- We moved the transformToJSDate to the date.js utilities file, in order to reuse it within comparePurchaseUrgency 
- We added a function purchaseUrgencyMessage to ListItem.jsx to return a text-based UI urgency indicator based on which group the item falls into (soon: next purchase date in 7 or less days; kind of soon: next purchase date in 7-30 days; not soon:  next purchase date in 30+ days; or inactive: last purchase date 60+ days ago).

## KNOWN BUGS
- This code has a couple of known bugs that need tweaking. 
- 1) When we manipulate the firebase data to create an inactive item, after testing out the item with different dates, the calculateEstimate function may estimate the dateNextPurchased to be 60+ days out. This causes the item to be excluded from the active items filtering in comparePurchaseUrgency function in firebase.js, and the item disappears from the list despite being active. The fix may be as simple as removing the "<60 " part of the active items filtering, however I'm not yet sure if that will cause unintended consequences.
- 2) The sorting algorithm sorts active items appropriately, but with inactive items, it sorts them by next purchase date. They are, however, still sorted last. I'm not sure if this is something that would be affected by the suggestion for the bug above. 

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

closes #12 

## Acceptance Criteria

- [x] Items in the list are shown with an indicator that tells the user they should buy the item “soon”, “kind of soon”, or “not soon”; or that the item is “inactive”
- [x] This urgency indicator does not rely on only color
- [x] api/firestore.js exports a new comparePurchaseUrgency function with the following behaviors
- [x] sorts inactive items last, then
- [x] sorts items in ascending order of days until purchase, and
- [x] sorts items with the same days until purchase alphabetically

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓  | :sparkles: New feature     |
| ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="868" alt="Screen Shot 2023-05-09 at 12 17 11 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/102475266/da90eff7-d4b2-4fc8-90fe-379ddaa2bac6">

### After

<img width="1440" alt="Screen Shot 2023-05-12 at 11 16 14 AM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/102399239/f3bf1da8-49ee-4a7b-bef8-66fe5cb1adc3">

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
