### PR TITLE
fix: address conditional logic to render inactive list items

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -36,13 +36,19 @@ export function ListItem({ item, listId }) {
 	}, [checked, item.dateLastPurchased]);
 
 	const purchaseUrgencyMessage = (item) => {
+		const dateLastPurchased = item.dateLastPurchased
+			? item.dateLastPurchased
+			: item.dateCreated;
+
 		const itemDays = getDaysBetweenDates(
 			transformToJSDate(item.dateNextPurchased),
 			new Date(),
 		);
-		const dateLastPurchased = item.dateLastPurchased
-			? item.dateLastPurchased
-			: item.dateCreated;
+
+		const itemDaysSinceLastPurchased = getDaysBetweenDates(
+			transformToJSDate(dateLastPurchased),
+			new Date(),
+		);
 
 		if (itemDays <= 7) {
 			return 'S';
@@ -50,7 +56,7 @@ export function ListItem({ item, listId }) {
 			return 'KS';
 		} else if (itemDays >= 30 && itemDays < 60) {
 			return 'NS';
-		} else if (itemDays > 60 || dateLastPurchased > 60) {
+		} else if (itemDaysSinceLastPurchased >= 60) {
 			return 'I';
 		}
 	};

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -40,7 +40,9 @@ export function ListItem({ item, listId }) {
 			transformToJSDate(item.dateNextPurchased),
 			new Date(),
 		);
-		const dateLastPurchased = item.dateLastPurchased;
+		const dateLastPurchased = item.dateLastPurchased
+			? item.dateLastPurchased
+			: item.dateCreated;
 
 		if (itemDays <= 7) {
 			return 'S';
@@ -48,7 +50,7 @@ export function ListItem({ item, listId }) {
 			return 'KS';
 		} else if (itemDays >= 30 && itemDays < 60) {
 			return 'NS';
-		} else if (itemDays > 60 && !dateLastPurchased) {
+		} else if (itemDays > 60 || dateLastPurchased > 60) {
 			return 'I';
 		}
 	};

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -50,13 +50,17 @@ export function ListItem({ item, listId }) {
 			new Date(),
 		);
 
-		if (itemDays <= 7) {
+		if (
+			itemDays <= 7 ||
+			(transformToJSDate(item.dateNextPurchased) < new Date() &&
+				itemDaysSinceLastPurchased < 60)
+		) {
 			return 'S';
 		} else if (itemDays > 7 && itemDays < 30) {
 			return 'KS';
 		} else if (itemDays >= 30 && itemDays < 60) {
 			return 'NS';
-		} else if (itemDaysSinceLastPurchased >= 60) {
+		} else {
 			return 'I';
 		}
 	};


### PR DESCRIPTION
## Description

This fix is to address a bug in the purchase urgency labels where inactive items were not labeled correctly due to an error in the sorting logic. The changes now convert the Firestore object with dateLastPurchased property into a JS object and perform getDaysBetweenDates for a number value of days between.

UPDATE: The changes also account for an edge case discovered from loading older lists with past due dateNextPurchased property. The conditional rendering for the label assignment was fixed to account for this particular edge case which was decided would be sorted as "Soon" to the very top of the list as most urgent. 

See "After" for a video demo of the oldest test list with the current changes. For the sake of the demo, the dateNextPurchased and dateLastPurchased item properties were displayed as strings for checking the accuracy of items being sorted in order. The changes will not have these date strings reflected on the items.

Thanks to @alucernoni for pointing out that we needed to account for an edge case and @drakenguyen4000 for noticing the bug in the sorting.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
<img width="480" alt="Screenshot 2023-05-24 at 9 44 31 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/93563580/4074eeb8-a8c0-41a0-a818-d85f95d91d97">

<img width="540" alt="Screenshot 2023-05-24 at 9 43 53 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/93563580/7b24809d-e1b5-4163-8ddb-793ddcc3821b">

### After

![ezgif com-optimize](https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/93563580/cf030cc3-f3dc-4621-b07e-a5d346ca464b)


## Testing Steps / QA Criteria

Testing the sorting using an older list was effective at spotting errors. You can pull the changes into a separate local branch and try with `my test list` to see the sorting.