### PR TITLE
Color contrast accessibility quick fix

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -124,5 +124,5 @@ ul {
 }
 
 .legendIcon {
-	@apply text-center mr-2 rounded-md h-11 w-12 bg-blue-400 text-white;
+	@apply text-center mr-2 rounded-md h-11 w-12 bg-blue-600 text-white;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -116,7 +116,7 @@ ul {
 }
 
 .inputField {
-	@apply shadow appearance-none border border-gray-500 rounded w-8/12 py-2 px-3 text-gray-700 m-2 leading-tight focus:outline-none;
+	@apply shadow appearance-none border border-gray-500 rounded w-8/12 py-2 px-3 text-gray-700 bg-blue-300 m-2 leading-tight focus:outline-none;
 }
 
 .h3 {

--- a/src/index.css
+++ b/src/index.css
@@ -108,7 +108,7 @@ ul {
 @tailwind utilities;
 
 .btn {
-	@apply bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded;
+	@apply bg-transparent hover:bg-blue-500 text-blue-800 bg-blue-300 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded;
 }
 
 .btn-delete {

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -12,7 +12,7 @@
 	text-shadow: 1px 1px gray;
 	font-size: 1.5rem;
 	line-height: 24px;
-	background: #2b90ca;
+	background: #247aab;
 	border-radius: 40px;
 	padding: 5%;
 	text-align: left;

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -9,14 +9,16 @@
 }
 
 .chippy-suggestion {
-	text-shadow: 1px 1px gray;
+	/* text-shadow: 1px 1px gray; */
 	font-size: 1.5rem;
 	line-height: 24px;
-	background: #247aab;
+	/* background: #247aab; */
+	background: #92c5fd;
 	border-radius: 40px;
 	padding: 5%;
 	text-align: left;
-	color: #fff;
+	/* color: #fff; */
+	color: #1d3faf;
 	bottom: 300px;
 	right: 15%;
 }


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._

## Description

This code changes the colors of the Chippy message, the search bar, the purchase urgency legend icons, and the "click here", "add item", and "clear" buttons on the List view to meet color contrast accessibility standards. It retains the overall theme of the original, just with starker contrast that works in both light and dark modes. I did not use all of the recommended colors from the accessibility insights, instead using adjacent colors from Tailwind's library in keeping with our theme.

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #42 

## Acceptance Criteria

- [ x] Color contrast in Chippy message bubble needs to be above 4.5. Suggested to use background color: #247aab and the original foreground color: #ffffff to meet a contrast ratio of 4.72:1
- [ x] Color contrast in purchase urgency tags need to be above 4.5. Suggested to use background color: #4477b5 and the original foreground color: #ffffff to meet a contrast ratio of 4.61:1.
- [x ] Color contrast in search bar needs to be above 4.5. Suggested to use foreground color: #8caddc and the original background color: #3b3b3b to meet a contrast ratio of 4.87:1.
- [x ] Color contrast in Add Item, Click Here, and Clear buttons needs to be above 4.5. Suggested to use foreground color: #3098ff and the original background color: #282c34 to meet a contrast ratio of 4.71:1.
- [x ] Run accessibility insights extension in both light and dark mode to ensure that the 4.5+ color contrast accessibility standard is being met

## Type of Changes


|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
|  | :sparkles: New feature     |
|   ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

**Light Mode**
<img width="566" alt="Screen Shot 2023-05-25 at 6 20 07 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/102399239/efa45b08-4bb4-49d4-a55f-8bf73c35b5a3">


**Dark Mode**

<img width="580" alt="Screen Shot 2023-05-25 at 6 19 38 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/102399239/5b0be4d7-0181-4f74-a346-430cddfe81d5">

### After

**Light Mode**

<img width="562" alt="Screen Shot 2023-05-25 at 6 17 30 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/102399239/ce38ef45-ce4b-4b12-98ff-657eb51057bb">

**Dark Mode**
<img width="563" alt="Screen Shot 2023-05-25 at 6 18 15 PM" src="https://github.com/the-collab-lab/tcl-56-smart-shopping-list/assets/102399239/00f9eb49-28c8-4e8c-ab86-56b73064683a">



## Testing Steps / QA Criteria

Download the Chrome Accessibility Insights extension. Click the extension and select the "FastPass" option to see if there are any accessibility issues identified. Then go to your computer's system preferences and toggle your preferences to dark/light mode (whichever was not your default), and repeat the test. 

Alternatively, to view the color contrast on each individual element, open up your Developer Tools. Use the pointer to click on each element, and under the "Accessibility" heading, observe that the contrast property is listed as 4.5 or above. 
